### PR TITLE
New location for ESET NOD32 executable scan.

### DIFF
--- a/package/Nod32Scan.desktop
+++ b/package/Nod32Scan.desktop
@@ -16,5 +16,5 @@ Version=5.21
 
 [Desktop Action scanwithNod32]
 Name=Scan with NOD32
-Exec=konsole --hold -e "bash -c 'echo; echo NOD32 Scan File; echo; echo %F; echo; nod32scan --unsafe --unwanted --clean-mode=none %F'"
+Exec=konsole --hold -e "bash -c 'echo; echo NOD32 Scan File; echo; echo %F; echo; opt/eset/esets/sbin/esets_scan --unsafe --unwanted --clean-mode=none %F'"
 Icon=security-medium

--- a/package/Nod32ScanPlusNotification.desktop
+++ b/package/Nod32ScanPlusNotification.desktop
@@ -16,5 +16,5 @@ Version=5.21
 
 [Desktop Action scanwithNod32]
 Name=Scan with NOD32
-Exec=sudo -u $(ps auxw | grep -i screen | grep -v grep | cut -f 1 -d ' ' | head -n 1) notify-send 'NOD32' 'Scan in progress please wait'; konsole --hold -e "bash -c 'echo; echo NOD32 Scan File; echo; echo %F; echo; nod32scan --unsafe --unwanted --clean-mode=none %F'"
+Exec=sudo -u $(ps auxw | grep -i screen | grep -v grep | cut -f 1 -d ' ' | head -n 1) notify-send 'NOD32' 'Scan in progress please wait'; konsole --hold -e "bash -c 'echo; echo NOD32 Scan File; echo; echo %F; echo; opt/eset/esets/sbin/esets_scan --unsafe --unwanted --clean-mode=none %F'"
 Icon=security-medium


### PR DESCRIPTION
Good afternoon @intika 

After reviewing your code and trying to make it work in opendesktop, I realized your pointing to a bin file that no longer exists.

Checking NOD32 scan exec, new location is opt/eset/esets/sbin/esets_scan.

After updating your .desktop files it works now correctly.

Cheers!